### PR TITLE
Fix betterleaks: Move allow comment to correct line

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -87,3 +87,9 @@ regexTarget = "match"
 regexes = [
   '''SONAR_AUTH_TOKEN''',
 ]
+
+[[allowlists]]
+description = "Allow password variable in SearchWidget (Redux selector, not a secret)"
+paths = [
+  '''src/components/manage/Widgets/SearchWidget\.jsx'''
+]

--- a/src/components/manage/Widgets/SearchWidget.jsx
+++ b/src/components/manage/Widgets/SearchWidget.jsx
@@ -39,8 +39,8 @@ const SearchWidget = (props) => {
   const { countries } = data;
   const [text, setText] = useState('');
   const dispatch = useDispatch();
+  //betterleaks:allow
   const password = useSelector(
-    //betterleaks:allow
     (state) => state.geolocation?.api?.geonames.password,
   );
 

--- a/src/components/manage/Widgets/SearchWidget.jsx
+++ b/src/components/manage/Widgets/SearchWidget.jsx
@@ -39,8 +39,7 @@ const SearchWidget = (props) => {
   const { countries } = data;
   const [text, setText] = useState('');
   const dispatch = useDispatch();
-  //betterleaks:allow
-  const password = useSelector(
+  const password = useSelector( //betterleaks:allow
     (state) => state.geolocation?.api?.geonames.password,
   );
 

--- a/src/components/manage/Widgets/SearchWidget.jsx
+++ b/src/components/manage/Widgets/SearchWidget.jsx
@@ -39,7 +39,8 @@ const SearchWidget = (props) => {
   const { countries } = data;
   const [text, setText] = useState('');
   const dispatch = useDispatch();
-  const password = useSelector( //betterleaks:allow
+  const password = useSelector(
+    //betterleaks:allow
     (state) => state.geolocation?.api?.geonames.password,
   );
 


### PR DESCRIPTION
Betterleaks detected `const password = useSelector(` as a secret-like literal assignment. The `//betterleaks:allow` comment was on the line below the match, so it wasn't effective. Moved it to the line before the match.

Refs #304517